### PR TITLE
fix(auth): add await to isAdmin middleware

### DIFF
--- a/backend/middleware/auth.js
+++ b/backend/middleware/auth.js
@@ -5,13 +5,20 @@ function isAuthenticated(req, res, next) {
     res.status(401).json({ success: false, message: 'No autenticado' });
 }
 
-function isAdmin(req, res, next) {
-    const User = require('../models/User');
-    const user = User.findById(req.session.userId);
-    if (user && user.role === 'admin') {
-        return next();
+async function isAdmin(req, res, next) {
+    try {
+        const User = require('../models/User');
+        const user = await User.findById(req.session.userId);
+        if (!user) {
+            return res.status(401).json({ success: false, message: 'No autenticado' });
+        }
+        if (user.role === 'admin') {
+            return next();
+        }
+        res.status(403).json({ success: false, message: 'Acceso denegado' });
+    } catch (err) {
+        res.status(500).json({ success: false, message: 'Error interno' });
     }
-    res.status(403).json({ success: false, message: 'Acceso denegado' });
 }
 
 module.exports = { isAuthenticated, isAdmin };


### PR DESCRIPTION
## Summary

The `isAdmin` middleware in `backend/middleware/auth.js` has a critical bug: `User.findById(req.session.userId)` is asynchronous but was not `await`ed. This caused `user` to always be a Promise (which is truthy), so `user.role` was always `undefined` — making the middleware always return 403.

## Fix

- Made `isAdmin` an `async` function
- Added `await` to `User.findById(...)`
- Added proper error handling (try/catch)
- Added null check for user not found case

Fixes #34